### PR TITLE
feat: improve skill scores for annolid

### DIFF
--- a/.github/workflows/skill-review.yml
+++ b/.github/workflows/skill-review.yml
@@ -1,0 +1,22 @@
+# Tessl Skill Review — runs on PRs that change any SKILL.md; posts scores as one PR comment.
+# Docs: https://github.com/tesslio/skill-review
+name: Tessl Skill Review
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "**/SKILL.md"
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: tesslio/skill-review@main
+      # Optional quality gate (off by default — do not enable unless user asked):
+      # with:
+      #   fail-threshold: 70

--- a/annolid/core/agent/skills/camera-realtime/SKILL.md
+++ b/annolid/core/agent/skills/camera-realtime/SKILL.md
@@ -1,6 +1,6 @@
 ---
-name: Camera Realtime Control
-description: Operate camera streams and realtime inference with model selection, status checks, and logging tools.
+name: camera-realtime
+description: "Start, monitor, and stop camera streams and realtime inference in Annolid with model selection, status checks, snapshot capture, and email reporting. Use when the user asks to open a camera feed, run realtime detection, check stream status, take snapshots, or email camera images."
 ---
 
 # Camera Realtime Control

--- a/annolid/core/agent/skills/gui/SKILL.md
+++ b/annolid/core/agent/skills/gui/SKILL.md
@@ -1,6 +1,6 @@
 ---
-name: GUI Automation
-description: Use Annolid GUI tools for robust automation across web, PDF, video, and chat controls.
+name: gui
+description: "Automate Annolid GUI interactions across web browsing, PDF reading, video analysis, and chat controls using dedicated GUI tools. Use when the user asks to open a URL, read a PDF, run video segmentation, control the chat UI, or perform any action that depends on current Annolid app state."
 ---
 
 # GUI Automation

--- a/annolid/core/agent/skills/logs/SKILL.md
+++ b/annolid/core/agent/skills/logs/SKILL.md
@@ -1,6 +1,6 @@
 ---
-name: Logs Manager
-description: Inspect, open, and clean Annolid logs using dedicated GUI log tools.
+name: logs
+description: "List, inspect, search, read, and clean Annolid log targets (logs, realtime, runs, label_index, app) using dedicated GUI log tools. Use when the user asks to view logs, search log content, open a log folder, read recent log entries, or delete old log files."
 ---
 
 # Logs Manager

--- a/annolid/core/agent/skills/mcp-search/SKILL.md
+++ b/annolid/core/agent/skills/mcp-search/SKILL.md
@@ -1,6 +1,6 @@
 ---
-name: "Playwright MCP & Browser Search Optimization"
-description: "Optimization guide for extracting information and using MCP browser tools effectively."
+name: mcp-search
+description: "Extract and search web content using Playwright MCP browser tools as a fallback when native Annolid web tools fail. Use when the user needs complex JavaScript evaluation, DOM extraction, or headless browser automation that gui_web_run_steps cannot handle."
 ---
 
 # MCP Browser & Search Capabilities

--- a/annolid/core/agent/skills/tmux/SKILL.md
+++ b/annolid/core/agent/skills/tmux/SKILL.md
@@ -1,19 +1,49 @@
 ---
 name: tmux
-description: Interact with tmux sessions for multi-process workflows.
+description: "Create, manage, and interact with tmux sessions for long-running processes and terminal multiplexing. Use when the user asks to run background jobs, manage terminal sessions, monitor long-running commands, split panes, or check on running processes."
 metadata: '{"annolid":{"requires":{"bins":["tmux"]}}}'
 ---
 
+# tmux Session Management
+
 Use this skill when the task involves long-running terminal jobs or session multiplexing.
 
-Suggested steps:
+## Workflow
 
-1. Discover sessions and windows before attaching.
-2. Send non-destructive commands first.
-3. Capture pane output for debugging/status updates.
-4. Keep session names explicit and task-specific.
+1. **Discover** existing sessions before creating new ones:
+   ```bash
+   tmux list-sessions
+   # Or use the bundled helper:
+   # scripts/find-sessions.sh
+   ```
+2. **Create** a named session for the task:
+   ```bash
+   tmux new-session -d -s <task-name>
+   ```
+3. **Send** commands to a target session/window:
+   ```bash
+   tmux send-keys -t <session>:<window> '<command>' Enter
+   ```
+4. **Capture** pane output for status checks:
+   ```bash
+   tmux capture-pane -t <session> -p | tail -20
+   ```
+5. **Poll** for expected output using the bundled helper:
+   ```bash
+   # scripts/wait-for-text.sh <session> <expected-token> <timeout-seconds>
+   ```
+6. **Kill** a session only when the user explicitly requests it:
+   ```bash
+   tmux kill-session -t <session>
+   ```
 
-Scripts:
+## Bundled Scripts
 
-- `scripts/find-sessions.sh`: list sessions
-- `scripts/wait-for-text.sh`: poll pane output for a token
+- `scripts/find-sessions.sh` — list all active tmux sessions with window counts
+- `scripts/wait-for-text.sh` — poll a pane for a specific token (useful for waiting on build/test completion)
+
+## Safety
+
+- Always list sessions before sending commands to verify the target exists.
+- Send non-destructive read commands first; confirm before running mutations.
+- Keep session names explicit and task-specific to avoid collisions.


### PR DESCRIPTION

Hey 👋 @healthonrails

I ran your skills through `tessl skill review` at work and found some targeted improvements. 

<img width="1312" height="910" alt="image" src="https://github.com/user-attachments/assets/fe0d8bb9-bb1d-4aec-a4cb-25d64a2048b5" />


Here's the full before/after:

| Skill | Before | After | Change |
|-------|--------|-------|--------|
| camera-realtime | 0% | 89% | +89% |
| gui | 0% | 89% | +89% |
| logs | 0% | 93% | +93% |
| mcp-search | 0% | 81% | +81% |
| tmux | 36% | 100% | +64% |

The four 0% skills were all blocked by name validation — their `name` frontmatter fields used spaces and uppercase instead of kebab-case. Once fixed, the LLM judge could actually evaluate them.

This PR intentionally caps changes at five skills to keep review manageable. The repo has 18 skills total — the included GitHub Action workflow (see next commit) will surface Tessl feedback on future `SKILL.md` changes so the rest can improve incrementally.

<details>
<summary>Changes made</summary>

**camera-realtime** (0% → 89%)
- Fixed `name` from "Camera Realtime Control" to "camera-realtime"
- Expanded description with specific capabilities and "Use when..." trigger clause

**gui** (0% → 89%)
- Fixed `name` from "GUI Automation" to "gui"
- Expanded description with specific actions (URL, PDF, video, chat) and "Use when..." clause

**logs** (0% → 93%)
- Fixed `name` from "Logs Manager" to "logs"
- Expanded description listing all log targets and operations with "Use when..." clause

**mcp-search** (0% → 81%)
- Fixed `name` from "Playwright MCP & Browser Search Optimization" to "mcp-search"
- Rewrote description to clarify fallback role and add "Use when..." clause

**tmux** (36% → 100%)
- Added comprehensive "Use when..." clause with natural trigger terms
- Added concrete executable bash command examples for each workflow step
- Documented bundled scripts with usage context
- Added safety section with guardrails

</details>

<details>
<summary>🔄 Included: Tessl Skill Review GitHub Action</summary>

This PR also adds `.github/workflows/skill-review.yml` — a lightweight GitHub Action that automatically reviews any `SKILL.md` changes on future PRs:

- **What it does:** On PRs that touch `**/SKILL.md`, it runs [`tesslio/skill-review`](https://github.com/tesslio/skill-review) and posts **one** PR comment with Tessl scores and feedback (updated on each push).
- **Zero extra accounts:** Contributors don't need a Tessl login — only the default `GITHUB_TOKEN` is used to post comments.
- **Non-blocking by default:** The check is feedback-only — no surprise red CI. Add `with: fail-threshold: 70` later if you want a hard gate.
- **Not a build replacement:** This is review automation for skill markdown, not a substitute for your existing CI pipelines.
- **Why only five skills here:** Keeps this PR reviewable. After merge, every PR that touches `SKILL.md` gets automatic review, so the rest of the library improves incrementally.

</details>

Honest disclosure — I work at @tesslio where we build tooling around skills like these. Not a pitch - just saw room for improvement and wanted to contribute.

Want to self-improve your skills? Just point your agent (Claude Code, Codex, etc.) at [this Tessl guide](https://docs.tessl.io/evaluate/optimize-a-skill-using-best-practices) and ask it to optimize your skill. Ping me - [@rohan-tessl](https://github.com/rohan-tessl) - if you hit any snags.

Thanks in advance 🙏

